### PR TITLE
Fixed some exploits

### DIFF
--- a/Items/Tokens/Token.cs
+++ b/Items/Tokens/Token.cs
@@ -8,7 +8,7 @@ public abstract class Token : ModItem
 {
     protected class TokenRecipeCreator
     {
-        private RecipeCreator _recipe = new();
+        private RecipeCreator _recipe = new(disableDecrafting:true);
         private int _tokenId;
 
         public TokenRecipeCreator(int tokenId)

--- a/RecipeManager.cs
+++ b/RecipeManager.cs
@@ -16,11 +16,13 @@ namespace imkSushisMod
         public static void AddRecipes()
         {
             var recipe = new RecipeCreator();
+            var recipeWithoutDecrafting = new RecipeCreator(disableDecrafting:true);
+
             AddExchangeRecipes(recipe);
             AddTaxedExchangeRecipes(recipe);
             AddMissingRecipes(recipe);
             AddDemonAltarRecipes(recipe);
-            AddMeltingDownRecipes(recipe);
+            AddMeltingDownRecipes(recipeWithoutDecrafting);
             AddDungeonChestRecipes(recipe);
             AddWoodenChestRecipes(recipe);
             AddOtherPotionRecipes(recipe);
@@ -38,7 +40,7 @@ namespace imkSushisMod
             AddMushroomChestRecipes(recipe);
             AddMinecartRecipes(recipe);
             AddTrapsRecipes(recipe);
-            AddUntrapChestRecipes(recipe);
+            AddUntrapChestRecipes(recipeWithoutDecrafting);
             AddCrateDowngradingRecipes(recipe);
         }
 

--- a/Tiles/AdamantiteMelter.cs
+++ b/Tiles/AdamantiteMelter.cs
@@ -35,8 +35,4 @@ public class AdamantiteMelter : ModTile
         g = 0.6f;
         b = 0.5f;
     }
-
-    public override void KillMultiTile(int x, int y, int frameX, int frameY) {
-        Item.NewItem(new EntitySource_TileBreak(x, y), x * 16, y * 16, 32, 32, ModContent.ItemType<Items.TileItems.AdamantiteMelter>());
-    }
 }

--- a/Tiles/Hellmelter.cs
+++ b/Tiles/Hellmelter.cs
@@ -35,8 +35,4 @@ public class Hellmelter : ModTile
         g = 0.45f;
         b = 0.25f;
     }
-
-    public override void KillMultiTile(int x, int y, int frameX, int frameY) {
-        Item.NewItem(new EntitySource_TileBreak(x, y), x * 16, y * 16, 32, 32, ModContent.ItemType<Items.TileItems.Hellmelter>());
-    }
 }

--- a/Tiles/Melter.cs
+++ b/Tiles/Melter.cs
@@ -33,8 +33,4 @@ public class Melter : ModTile
         g = 0.6f;
         b = 0.5f;
     }
-
-    public override void KillMultiTile(int x, int y, int frameX, int frameY) {
-        Item.NewItem(new EntitySource_TileBreak(x, y), x * 16, y * 16, 32, 32, ModContent.ItemType<Items.TileItems.Melter>());
-    }
 }

--- a/Tiles/TitaniumMelter.cs
+++ b/Tiles/TitaniumMelter.cs
@@ -35,8 +35,4 @@ public class TitaniumMelter : ModTile
         g = 0.6f;
         b = 0.5f;
     }
-
-    public override void KillMultiTile(int x, int y, int frameX, int frameY) {
-        Item.NewItem(new EntitySource_TileBreak(x, y), x * 16, y * 16, 32, 32, ModContent.ItemType<Items.TileItems.TitaniumMelter>());
-    }
 }

--- a/build.txt
+++ b/build.txt
@@ -1,4 +1,4 @@
 displayName = imkSushi's Mod
 author = imkSushi
-version = 5.1.2
+version = 5.1.3
 homepage = http://forums.terraria.org/index.php?threads/imksushis-mod.34233/


### PR DESCRIPTION
I added in two ways to block decrafting in the RecipeCreator.

The first one is a generalized so that if a recipe contains certain ingredients or uses a certain crafting station, it will only allow decrafting once specific conditions are met. This automatically applies to all recipes made with the RecipeCreator.

The second one is when you create the RecipeCreator, you can specify to disable decrafting on all recipes it creates.
Melter, Tokens, and Untrapping Chest recipes all needed decrafting disabled to prevent exploits.
